### PR TITLE
Save and load `ScionLight` correctly

### DIFF
--- a/scion.py
+++ b/scion.py
@@ -377,13 +377,15 @@ class ScionLight(torch.optim.Optimizer):
     def _store_grads_in_state(self):
         for group in self.param_groups:
             for param in group['params']:
-                if isinstance(param, torch.Tensor):
+                if isinstance(param, torch.Tensor) and param.grad is not None:
                     self.state.setdefault(param, {})['grad_state'] = param.grad
 
     def _load_grads_from_state(self):
         for (param, state) in self.state.items():
             if 'grad_state' in state:
                 param.grad = state['grad_state']
+            elif isinstance(param, torch.Tensor):
+                param.grad = None
 
 
 @torch.compile

--- a/scion.py
+++ b/scion.py
@@ -374,6 +374,14 @@ class ScionLight(torch.optim.Optimizer):
                 init_func(p)
                 p.data *= scale
 
+    def __getstate__(self):
+        self._store_grads_in_state()
+        return super().__getstate__()
+
+    def __setstate__(self, state):
+        super().__setstate__(state)
+        self._load_grads_from_state()
+
     def _store_grads_in_state(self):
         for group in self.param_groups:
             for param in group['params']:

--- a/scion.py
+++ b/scion.py
@@ -1,6 +1,4 @@
-from itertools import chain
 import math
-
 import torch
 
 


### PR DESCRIPTION
The gradients of the parameters contain extremely important state for `ScionLight` to function correctly. We solve this by storing/loading the gradients in/from the state dict.

Thanks @rakkit for the awareness of this problem.